### PR TITLE
Update install command to include full version

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
 
         <p>Lerna 2.x is the recommended version to start with (currently in beta).</p>
 
-        <pre class="pre--command pre--centered"><code>npm install --global lerna@^2.0.0-beta</code></pre>
+        <pre class="pre--command pre--centered"><code>npm install --global lerna@^2.0.0-beta.0</code></pre>
 
         <p>
           Next we'll create a new git repository:


### PR DESCRIPTION
This command fails: `npm install --global lerna@^2.0.0-beta` because it doesn't include the full version name. Updated to `^2.0.0-beta.0` which will always install the latest beta version.

Fixes lerna/lerna#550