### PR TITLE
FrintJS is using Lerna

### DIFF
--- a/index.html
+++ b/index.html
@@ -268,6 +268,7 @@
             <li><a href="https://github.com/openzipkin/zipkin-js">openzipkin/zipkin-js</a></li>
             <li><a href="https://github.com/vudash/vudash">vudash/vudash</a></li>
             <li><a href="https://github.com/nteract/commuter">nteract/commuter</a></li>
+            <li><a href="https://github.com/Travix-International/frint">Travix-International/frint</a></li>
           </ul>
       </section>
     </article>


### PR DESCRIPTION
Added FrintJS under 'Who's using Lerna?'.

## Links

* Docs: https://frint.js.org
* GitHub: https://github.com/Travix-International/frint
* Blog post: https://travix.io/introducing-frintjs-a9a8cdd29812#.va6wo6l8g