### PR TITLE
FrintJS URL updated

### DIFF
--- a/index.html
+++ b/index.html
@@ -271,7 +271,7 @@
             <li><a href="https://github.com/openzipkin/zipkin-js">openzipkin/zipkin-js</a></li>
             <li><a href="https://github.com/vudash/vudash">vudash/vudash</a></li>
             <li><a href="https://github.com/nteract/commuter">nteract/commuter</a></li>
-            <li><a href="https://github.com/Travix-International/frint">Travix-International/frint</a></li>
+            <li><a href="https://github.com/frintjs/frint">frintjs/frint</a></li>
             <li><a href="https://github.com/fyndiq/fyndiq-ui">fyndiq/fyndiq-ui</a></li>
             <li><a href="https://github.com/azu/immutable-array-prototype">azu/immutable-array-prototype</a></li>
             <li><a href="https://github.com/TrueCar/gluestick">TrueCar/gluestick</a></li>


### PR DESCRIPTION
The project has moved into an organization now: https://github.com/frintjs/frint

Thanks for all the hard work in Lerna! We highly benefit from it in our monorepo 🎉 