### PR TITLE
Adding `WordPress/packages` to `Who's using lerna`

### DIFF
--- a/index.html
+++ b/index.html
@@ -279,6 +279,7 @@
             <li><a href="https://github.com/phenomic/phenomic">phenomic/phenomic</a></li>
             <li><a href="https://github.com/sterjakovigor/vqua">sterjakovigor/vqua</a></li>
             <li><a href="https://github.com/wireapp/wire-web-packages">wireapp/wire-web-packages</a></li>
+            <li><a href="https://github.com/WordPress/packages">WordPress/packages</a></li>
           </ul>
       </section>
     </article>


### PR DESCRIPTION
Collection of JS modules and tools for WordPress development is maintained with Lerna. Many thanks for developing such a great tool. Kudos to the team!