### PR TITLE
Add Gatsby to the list of projects using Lerna

### DIFF
--- a/index.html
+++ b/index.html
@@ -295,8 +295,9 @@
             <li><a href="https://github.com/FoalTS/foal">FoalTS/foal</a></li>
             <li><a href="https://github.com/emotion-js/emotion">emotion-js/emotion</a></li>
             <li><a href="https://github.com/Bamieh/reflow/">Bamieh/reflow</a></li>
-            <li><a href="https://github.com/transloadit/uppy/">transloadit/uppy</a></li>            
-            <li><a href="https://github.com/olistic/warriorjs">olistic/warriorjs</a></li>
+            <li><a href="https://github.com/transloadit/uppy/">transloadit/uppy</a></li>
+            <li><a href="https://github.com/olistic/warriorjs">olistic/warriorjs</a></li>        
+            <li><a href="https://github.com/gatsbyjs/gatsby">gatsbyjs/gatsby</a></li>
           </ul>
       </section>
     </article>


### PR DESCRIPTION
Following lerna/lerna#1531 and gatsbyjs/gatsby#6948

> On your project homepage as well as on your README are listed a few popular projects using Lerna. [Gatsby](http://gatsbyjs.org/) is gaining momentum lately and adding this project to your list seems appropriate.