### PR TITLE
Add zeit/next.js to "Who's using Lerna?"

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,7 +140,7 @@
             <code>lerna import &lt;pathToRepo&gt;</code>
           </a></h3>
           <p>
-            Import the package in the local path &lt;pathToRepo&gt; into packages/&lt;directory-name&gt; with commit history. 
+            Import the package in the local path &lt;pathToRepo&gt; into packages/&lt;directory-name&gt; with commit history.
           </p>
         </section>
 
@@ -295,7 +295,7 @@
             <li><a href="https://github.com/emotion-js/emotion">emotion-js/emotion</a></li>
             <li><a href="https://github.com/Bamieh/reflow/">Bamieh/reflow</a></li>
             <li><a href="https://github.com/transloadit/uppy/">transloadit/uppy</a></li>
-            <li><a href="https://github.com/olistic/warriorjs">olistic/warriorjs</a></li>        
+            <li><a href="https://github.com/olistic/warriorjs">olistic/warriorjs</a></li>
             <li><a href="https://github.com/gatsbyjs/gatsby">gatsbyjs/gatsby</a></li>
             <li><a href="https://github.com/feathersjs/feathers">feathersjs/feathers</a></li>
             <li><a href="https://github.com/vuejs/vue-cli">vuejs/vue-cli</a></li>
@@ -304,6 +304,7 @@
             <li><a href="https://github.com/SBoudrias/Inquirer.js">SBoudrias/Inquirer.js</a></li>
             <li><a href="https://github.com/pedronauck/docz">pedronauck/docz</a></li>
             <li><a href="https://github.com/tasitlabs/tasitsdk">tasitlabs/tasitsdk</a></li>
+            <li><a href="https://github.com/zeit/next.js">zeit/next.js</a></li>
           </ul>
       </section>
     </article>


### PR DESCRIPTION
[Next.js](https://github.com/zeit/next.js) created by @zeit uses @lerna. This PR add Next.js to the "Who's using Lerna" section.