### PR TITLE
Add webpack/webpack-cli to "Who's using Lerna?"

### DIFF
--- a/index.html
+++ b/index.html
@@ -305,6 +305,7 @@
             <li><a href="https://github.com/pedronauck/docz">pedronauck/docz</a></li>
             <li><a href="https://github.com/tasitlabs/tasitsdk">tasitlabs/tasitsdk</a></li>
             <li><a href="https://github.com/zeit/next.js">zeit/next.js</a></li>
+            <li><a href="https://github.com/webpack/webpack-cli">webpack/webpack-cli</a></li>
           </ul>
       </section>
     </article>


### PR DESCRIPTION
Webpack org has a repo webpack-cli which uses @lerna .
This PR add webpack-cli to the "Who's using Lerna" section.