### PR TITLE
Improve typography and readability

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -129,7 +129,6 @@ pre code {
   max-width: 40rem;
   margin: 3rem auto 7rem;
   padding: 0 1.5rem;
-  text-align: justify;
   color: #333;
 }
 


### PR DESCRIPTION
Most browsers' text flow engines don't handle `text-align: justify;` well, especially without hyphenation. Eliminating this CSS rule improves the readability of the text considerably, especially on narrower viewports.

With `text-align: justify;` 😩|Without `text-align: justify;` 🥳
-|-
<img width="300" alt="Screenshot of text flow with justified text (current)" src="https://user-images.githubusercontent.com/171986/62406710-e089e000-b564-11e9-8aaa-f8fdb3b2ca57.png">|<img width="303" alt="Screenshot of text flow without justified text (proposed)" src="https://user-images.githubusercontent.com/171986/62406714-e54e9400-b564-11e9-8f1f-f5497a3c01f0.png">
