### PR TITLE
clarify prerequisite for lerna import

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,7 +140,9 @@
             <code>lerna import &lt;pathToRepo&gt;</code>
           </a></h3>
           <p>
-            Import the package in the local path &lt;pathToRepo&gt; into packages/&lt;directory-name&gt; with commit history.
+            Import the package in the local path &lt;pathToRepo&gt; into packages/&lt;directory-name&gt; 
+            with commit history. You will get <a href="https://github.com/lerna/lerna/blob/master/doc/troubleshooting.md#failing-when-git-tree-has-uncommitted-changes">an error</a> 
+            if you don't first <code>git commit</code> your lerna repo's changes.
           </p>
         </section>
 


### PR DESCRIPTION
On [the repo's page for this method](https://github.com/lerna/lerna/tree/master/commands/import#readme), this is covered.
It's also covered [in the troubleshooting doc](https://github.com/lerna/lerna/blob/master/doc/troubleshooting.md#failing-when-git-tree-has-uncommitted-changes).

However, that's not where first-timers (like myself) start. I started on the website, and this was very unclear and the error message very unhelpful. In lieu of a better error message from the CLI, this should suffice.