### PR TITLE
fix: change name zeit to vercel

### DIFF
--- a/index.html
+++ b/index.html
@@ -304,7 +304,7 @@
             <li><a href="https://github.com/SBoudrias/Inquirer.js">SBoudrias/Inquirer.js</a></li>
             <li><a href="https://github.com/pedronauck/docz">pedronauck/docz</a></li>
             <li><a href="https://github.com/tasitlabs/tasitsdk">tasitlabs/tasitsdk</a></li>
-            <li><a href="https://github.com/zeit/next.js">zeit/next.js</a></li>
+            <li><a href="https://github.com/vercel/next.js">vercel/next.js</a></li>
             <li><a href="https://github.com/react-bootstrap-table/react-bootstrap-table2">react-bootstrap-table/react-bootstrap-table2</a></li>
             <li><a href="https://github.com/webpack/webpack-cli">webpack/webpack-cli</a></li>
             <li><a href="https://github.com/reakit/reakit">reakit/reakit</a></li>


### PR DESCRIPTION
Updated name from zeit to Vercel in "Who's using Lerna?"